### PR TITLE
Fix offline time exploit

### DIFF
--- a/Passive.txt
+++ b/Passive.txt
@@ -40,6 +40,7 @@ func Init()
   // Display offline gain dialog
   DisplayOfflineGain()
   progress.AddScales(offline.totalScalesOffline)
+  progress.UpdateLastOnline()
   topHud.Update()
 
 func AddNewHire(level)


### PR DESCRIPTION
Explanation of the exploit:
The exploit was done by repeatedly entering and leaving the location. By leaving quickly enough, `key_last_online` never updated, and since `key_scales` did update it led to the amount of scales earned each time the location was entered to keep increasing.

Fix:
Added `progress.UpdateLastOnline()` to the `Init` function in `Passive` so the last online was updated at the same time the scales were.