### PR TITLE
Fix scales storage type

### DIFF
--- a/Progress.txt
+++ b/Progress.txt
@@ -1,5 +1,6 @@
-
 var scales = storage.Get("key_scales", 0)
+?Type(scales) = object
+  scales = int.Parse(scales + "")
 var recordWeight = storage.Get("key_record", 0)
 var rod = storage.Get("key_rod", 0)
 var lastOnline = storage.Get("key_last_online", 0)
@@ -12,11 +13,11 @@ var hirelings = [ storage.Get("key_hireling_0", 0),
                   storage.Get("key_hireling_6", 0)]
 
 func AddScales(amount)
-  scales = scales + amount
+  scales = math.FloorToInt(scales + amount)
   storage.Set("key_scales", scales)
 
 func SubtractScales(amount)
-  scales = scales - amount
+  scales = math.FloorToInt(scales - amount)
   storage.Set("key_scales", scales)
 
 func CheckRecord(newWeight)


### PR DESCRIPTION
Explanation of the bug:
When `key_scales` was saved as a float instead of an int, after restarting the game `storage.Get("key_scales", 0)` would return an object, which meant scales could no longer be updated by the game logic and would essentially put the user into soft lock.

Fix:
Force `key_scales` to an integer, which doesn't appear to have problems after restarting the game. Since the object returned by `storage.Get("key_scales", 0)` has a `.ToString()` value of the correct number, we can check it's type and convert it to an integer. This allows previously broken saves to be fixed automatically.

Note:
This might be caused by a bug in the game itself not handling `float` types in storage correctly. Needing to restart the game to reproduce the bug leads me to believe this is the case. If this is a bug with the game and can be fixed by the devs then this fix could probably be removed in the future, otherwise I propose we do this type validation and conversion for everything in storage.